### PR TITLE
Fix #23: Bug in Instant.toString

### DIFF
--- a/src/main/scala/java/time/Instant.scala
+++ b/src/main/scala/java/time/Instant.scala
@@ -271,7 +271,7 @@ final class Instant private (private val seconds: Long, private val nanos: Int)
 
     val timePart = {
       val timeStr = time.toString
-      if (time.getSecond == 0) timeStr + ":00"
+      if (time.getSecond == 0 && time.getNano == 0) timeStr + ":00"
       else timeStr
     }
 

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/InstantTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/InstantTest.scala
@@ -373,6 +373,10 @@ class InstantTest extends TemporalTest[Instant] {
   @Test def toStringOutput(): Unit = {
     assertEquals("1970-01-01T00:00:00Z", Instant.EPOCH.toString)
     assertEquals("-1000000000-01-01T00:00:00Z", Instant.MIN.toString)
+
+    // https://github.com/scala-js/scala-js-java-time/issues/23
+    assertEquals("1970-01-01T00:10:00.100Z", Instant.EPOCH.plus(10, MINUTES).plusMillis(100).toString)
+
     assertEquals("+1000000000-12-31T23:59:59.999999999Z", Instant.MAX.toString)
     assertEquals("1999-06-03T06:56:23.942Z", somePositiveInstant.toString)
     assertEquals("-0687-08-07T23:38:33.088936253Z", someNegativeInstant.toString)


### PR DESCRIPTION
Fix a bug where an extra `:00` would be added to the `toString` if the
seconds field is 0 but the nanos field is not.

Also, there seems to be an issue when running the tests locally. If I run the tests it is fine, but if I modify the source code (not the tests) then when I go to run the tests I get several "non existent methods" error. 

> Referring to non-existent method java.time.Instant.range(java.time.temporal.TemporalField)java.time.temporal.ValueRange

After that happens I have to clean my targets `git clean -xfd` before I can run the tests again. Modifying the tests do not cause said issue to occur. 