### PR TITLE
Implement Instant.parse and LocalDate.parse.

### DIFF
--- a/src/main/scala/java/time/Constants.scala
+++ b/src/main/scala/java/time/Constants.scala
@@ -46,4 +46,8 @@ private[time] object Constants {
   final val SECONDS_IN_WEEK = SECONDS_IN_DAY * 7
 
   final val SECONDS_IN_MONTH = 2629746
+
+  final val DAYS_IN_LEAP_YEAR = 366
+
+  final val DAYS_IN_YEAR = 365
 }

--- a/src/main/scala/java/time/Preconditions.scala
+++ b/src/main/scala/java/time/Preconditions.scala
@@ -1,9 +1,17 @@
 package java.time
 
+import java.time.format.DateTimeParseException
+
 private[time] object Preconditions {
   // Like scala.Predef.require, but throws a DateTimeException.
   def requireDateTime(requirement: Boolean, message: => Any): Unit = {
     if (!requirement)
       throw new DateTimeException(message.toString)
+  }
+
+  def requireDateTimeParse(requirement: Boolean, message: => Any,
+      charSequence: CharSequence, index: Int): Unit = {
+    if (!requirement)
+      throw new DateTimeParseException(message.toString, charSequence, index)
   }
 }

--- a/src/main/scala/java/time/format/DateTimeParseException.scala
+++ b/src/main/scala/java/time/format/DateTimeParseException.scala
@@ -1,0 +1,14 @@
+package java.time.format
+
+import java.time.DateTimeException
+
+class DateTimeParseException(message: String, parsedData: CharSequence,
+    errorIndex: Int, cause: Throwable)
+    extends DateTimeException(message, cause) {
+
+  def this(message: String, parsedData: CharSequence, errorIndex: Int) =
+    this(message, parsedData, errorIndex, null)
+
+  def getErrorIndex(): Int = errorIndex
+  def getParsedString(): String = parsedData.toString
+}

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/LocalDateTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/LocalDateTest.scala
@@ -2,6 +2,7 @@ package org.scalajs.testsuite.javalib.time
 
 import java.time._
 import java.time.chrono.{IsoEra, IsoChronology}
+import java.time.format.DateTimeParseException
 import java.time.temporal._
 
 import org.junit.Test
@@ -811,5 +812,23 @@ class LocalDateTest extends TemporalTest[LocalDate] {
 
     for (t <- Seq(LocalTime.MIN, LocalTime.NOON, LocalTime.MAX))
       expectThrows(classOf[DateTimeException], from(t))
+  }
+
+  @Test def test_parse(): Unit = {
+    assertEquals(parse("-999999999-01-01"), MIN)
+    assertEquals(parse("-0001-12-31"), of(-1, 12, 31))
+    assertEquals(parse("0000-01-01"), of(0, 1, 1))
+    assertEquals(parse("2011-02-28"), someDate)
+    assertEquals(parse("2012-02-29"), leapDate)
+    assertEquals(parse("9999-12-31"), of(9999, 12, 31))
+    assertEquals(parse("+10000-01-01"), of(10000, 1, 1))
+    assertEquals(parse("+999999999-12-31"), MAX)
+
+    expectThrows(classOf[DateTimeParseException], parse("0000-01-99"))
+    expectThrows(classOf[DateTimeParseException], parse("0000-01-900"))
+    expectThrows(classOf[DateTimeParseException], parse("aaaa-01-30"))
+    expectThrows(classOf[DateTimeParseException], parse("2012-13-30"))
+    expectThrows(classOf[DateTimeParseException], parse("2012-01-34"))
+    expectThrows(classOf[DateTimeParseException], parse("2005-02-29"))
   }
 }


### PR DESCRIPTION
- Implemented `parse` method for `java.time.Instant`
- Implemented `parse` method for `java.time.LocalDate`
- Fixed bug with `toString` method in `java.time.Instant`

Fixes: https://github.com/scala-js/scala-js-java-time/issues/35