### PR TITLE
Upgrades.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,23 @@ script:
 scala:
   - 2.10.7
   - 2.11.12
-  - 2.12.5
+  - 2.12.6
   - 2.13.0-M3
   - 2.13.0-M4
 jdk:
   - oraclejdk8
 env:
-  - SCALAJS_VERSION=0.6.23
+  - SCALAJS_VERSION=0.6.24
   - SCALAJS_VERSION=1.0.0-M3
+  - SCALAJS_VERSION=1.0.0-M5
 matrix:
   exclude:
     - scala: 2.10.7
       env: SCALAJS_VERSION=1.0.0-M3
     - scala: 2.13.0-M4
       env: SCALAJS_VERSION=1.0.0-M3
+    - scala: 2.10.7
+      env: SCALAJS_VERSION=1.0.0-M5
 
 cache:
   directories:

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,14 @@
 import sbtcrossproject.crossProject
 
-crossScalaVersions in ThisBuild := Seq("2.12.5", "2.11.12", "2.10.7", "2.13.0-M3", "2.13.0-M4")
+crossScalaVersions in ThisBuild := {
+  val allVersions = Seq("2.12.6", "2.11.12", "2.10.7", "2.13.0-M3", "2.13.0-M4")
+  if (scalaJSVersion.startsWith("0.6."))
+    allVersions
+  else if (scalaJSVersion == "1.0.0-M3")
+    allVersions.filter(v => !v.startsWith("2.10.") && v != "2.13.0-M4")
+  else
+    allVersions.filter(!_.startsWith("2.10."))
+}
 scalaVersion in ThisBuild := (crossScalaVersions in ThisBuild).value.head
 
 val commonSettings: Seq[Setting[_]] = Seq(

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,7 +1,7 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.23")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.24")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")

--- a/src/main/scala/java/time/LocalDate.scala
+++ b/src/main/scala/java/time/LocalDate.scala
@@ -391,7 +391,7 @@ object LocalDate {
 
   def now(): LocalDate = {
     val d = new js.Date()
-    of(d.getFullYear, d.getMonth + 1, d.getDate)
+    of(d.getFullYear.toInt, d.getMonth.toInt + 1, d.getDate.toInt)
   }
 
   // Not implemented

--- a/src/main/scala/java/time/LocalTime.scala
+++ b/src/main/scala/java/time/LocalTime.scala
@@ -323,8 +323,9 @@ object LocalTime {
 
   def now(): LocalTime = {
     val date = new js.Date()
-    val nano = date.getMilliseconds * 1000000
-    new LocalTime(date.getHours, date.getMinutes, date.getSeconds, nano)
+    val nano = date.getMilliseconds.toInt * 1000000
+    new LocalTime(date.getHours.toInt, date.getMinutes.toInt,
+        date.getSeconds.toInt, nano)
   }
 
   // Not implemented

--- a/src/main/scala/java/time/chrono/Chronology.scala
+++ b/src/main/scala/java/time/chrono/Chronology.scala
@@ -26,7 +26,7 @@ trait Chronology extends Comparable[Chronology] {
 
   def dateNow(): ChronoLocalDate = {
     val d = new js.Date()
-    date(d.getFullYear, d.getMonth, d.getDate)
+    date(d.getFullYear.toInt, d.getMonth.toInt, d.getDate.toInt)
   }
 
   // Not implemented


### PR DESCRIPTION
* Scala 2.12.5 -> 2.12.6
* sbt-crossproject 0.3.0 -> 0.5.0 (for Scala.js 1.0.0-M4 support)
* Add Scala.js 1.0.0-M4

Support for Scala.js 1.0.0-M4 required to add some `.toInt`s to the result of methods on `js.Date`, since they became `Double`s upstream.