### PR TITLE
Fix source map URL

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,16 @@ val commonSettings: Seq[Setting[_]] = Seq(
   organization := "org.scala-js",
   scalacOptions ++= Seq("-deprecation", "-feature", "-Xfatal-warnings"),
 
+  scalacOptions ++= {
+    if (isSnapshot.value)
+      Seq.empty
+    else {
+      val a = baseDirectory.value.toURI
+      val g = "https://raw.githubusercontent.com/scala-js/scala-js-java-time"
+      Seq(s"-P:scalajs:mapSourceURI:$a->$g/v${version.value}/")
+    }
+  },
+
   homepage := Some(url("http://scala-js.org/")),
   licenses += ("BSD New",
       url("https://github.com/scala-js/scala-js-java-time/blob/master/LICENSE")),


### PR DESCRIPTION
Currently I'm seeing the following in the artifacts on Maven Central:

```
file://localhome/doeraene/projects/scalajs-java-time/java/time/chrono/AbstractChronology.scala
```